### PR TITLE
:cyclone: path alias を廃止する

### DIFF
--- a/apps/app1/src/pages/_app.page.tsx
+++ b/apps/app1/src/pages/_app.page.tsx
@@ -1,4 +1,4 @@
-import '@learn-monorepo-pnpm/core/styles/app.scss';
+import '@learn-monorepo-pnpm/core/src/styles/app.scss';
 import { type AppProps } from 'next/app';
 
 const App = ({ Component, pageProps }: AppProps) => (

--- a/apps/app1/src/templates/home/index.tsx
+++ b/apps/app1/src/templates/home/index.tsx
@@ -1,5 +1,5 @@
-import { FormLabel } from '@learn-monorepo-pnpm/core/components/inputs/FormLabel';
-import { useDebouncedState } from '@learn-monorepo-pnpm/core/hooks/useDebouncedState';
+import { FormLabel } from '@learn-monorepo-pnpm/core/src/components/inputs/FormLabel';
+import { useDebouncedState } from '@learn-monorepo-pnpm/core/src/hooks/useDebouncedState';
 import { useState } from 'react';
 import styles from './index.module.scss';
 

--- a/apps/app1/tsconfig.json
+++ b/apps/app1/tsconfig.json
@@ -1,10 +1,6 @@
 {
   "extends": "@learn-monorepo-pnpm/tsconfig/tsconfig.base",
   "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {
-      "@learn-monorepo-pnpm/core/*": ["../../packages/core/src/*"]
-    },
     "plugins": [
       {
         "name": "next"

--- a/apps/app2/src/App/index.tsx
+++ b/apps/app2/src/App/index.tsx
@@ -1,4 +1,4 @@
-import { LabeledSlider } from '@learn-monorepo-pnpm/core/components/inputs/LabeledSlider';
+import { LabeledSlider } from '@learn-monorepo-pnpm/core/src/components/inputs/LabeledSlider';
 import { useMemo, useState } from 'react';
 import styles from './index.module.scss';
 

--- a/apps/app2/tsconfig.json
+++ b/apps/app2/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "extends": "@learn-monorepo-pnpm/tsconfig/tsconfig.base",
   "compilerOptions": {
-    "types": ["vite/client"],
-    "baseUrl": "./",
-    "paths": {
-      "@learn-monorepo-pnpm/core/*": ["../../packages/core/src/*"]
-    }
+    "types": ["vite/client"]
   },
   "include": ["./src/**/*", "../../packages/core/src/*.d.ts", "vite.config.ts"],
   "exclude": ["node_modules"]

--- a/apps/app2/vite.config.ts
+++ b/apps/app2/vite.config.ts
@@ -10,9 +10,4 @@ export default defineConfig({
     open: true,
   },
   plugins: [react()],
-  resolve: {
-    alias: {
-      '@learn-monorepo-pnpm/core': resolve(__dirname, '../../packages/core/src'),
-    },
-  },
 });

--- a/apps/catalog/.storybook/main.js
+++ b/apps/catalog/.storybook/main.js
@@ -24,11 +24,6 @@ module.exports = {
     autodocs: true,
   },
   webpackFinal: async (config) => {
-    // 各サブパッケージ配下のコードにある path alias を Storybook に認識させる。
-    config.resolve.alias = {
-      ...config.resolve.alias,
-      '@learn-monorepo-pnpm/core': resolve(__dirname, '../../../packages/core/src'),
-    };
     // 各サブパッケージ配下のコードにある CSS Modules (Sass) を Storybook に認識させる。
     config.module.rules.push({
       test: /\.scss$/,

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,8 +1,4 @@
 {
   "extends": "@learn-monorepo-pnpm/tsconfig/tsconfig.base",
-  "compilerOptions": {
-    "baseUrl": "./",
-    "paths": {}
-  },
   "include": ["./src/**/*"]
 }


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

<!-- 必須 -->
<!-- なぜこの変更をするのか、課題は何か、これによってどう解決されるのかなど、この変更を行った理由を記述 -->

catalog パッケージの TypeScript を 5x にマイグレーションするため。 Storybook は v7 以上でないと TypeScript 5 をサポートしない。

### 何を変更したのか

<!-- 必須 -->
<!-- この作業ブランチで何を変更をしたかの概要を記述 -->

ワークスペース配下のサブパッケージを参照する際に path alias を設定して import path を省略するのをやめた。

### 技術的にはどこがポイントか

<!-- 任意: やむを得ない事情が無い限り記述すること。 -->
<!-- レビュワーに伝わるように技術的視線での変更概要説明 -->

長らく monorepo の設計に組み込んでいた path alias を使った `src/` の省略をやめ、素直にフルパスで import するようにした。`tsconfig.json` の `paths` プロパティや `vite.config` の `resolve.alias` に設定の追記が必要なのと、Storybook が正しくパス解決できずビルドに失敗してしまうことが主な理由である。

また、よくよく考えてみれば import しているのはビルド済みのモジュールではなく「ソースコード」そのものなので、パスに `src/` が含まれる方が自然である。これさえ受け入れれば全てが合理的かつシンプルに落ち着くため、数年続けた path alias を使った設計を捨てることにした。

